### PR TITLE
Feat/implement sources controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,21 +62,24 @@ resources:
 Some configuration parameters can be defined by flags that can be passed to the controller.
 They are described in the following table:
 
-| Name                           | Description                                                                    |        Default         |
-|:-------------------------------|:-------------------------------------------------------------------------------|:----------------------:|
-| `--metrics-bind-address`       | The address the metric endpoint binds to. </br> 0 disables the server          |          `0`           |
-| `--health-probe-bind-address`  | he address the probe endpoint binds to                                         |        `:8081`         |
-| `--leader-elect`               | Enable leader election for controller manager                                  |        `false`         |
-| `--metrics-secure`             | If set the metrics endpoint is served securely                                 |        `false`         |
-| `--enable-http2`               | If set, HTTP/2 will be enabled for the metrirs                                 |        `false`         |
-| `--webhook-client-hostname`    | The hostname used by Kubernetes when calling the webhooks server               | `webhooks.admitik.svc` |
-| `--webhook-client-port`        | The port used by Kubernetes when calling the webhooks server                   |        `10250`         |
-| `--webhook-client-timeout`     | The seconds until timout waited by Kubernetes when calling the webhooks server |          `10`          |
-| `--webhook-server-port`        | The port where the webhooks server listens                                     |        `10250`         |
-| `--webhook-server-path`        | The path where the webhooks server listens                                     |      `/validate`       |
-| `--webhook-server-ca`          | The CA bundle to use for the webhooks server                                   |          `-`           |
-| `--webhook-server-certificate` | The Certificate used by webhooks server                                        |          `-`           |
-| `--webhook-server-private-key` | The Private Key used by webhooks server                                        |          `-`           |
+| Name                                   | Description                                                                    |        Default         |
+|:---------------------------------------|:-------------------------------------------------------------------------------|:----------------------:|
+| `--metrics-bind-address`               | The address the metric endpoint binds to. </br> 0 disables the server          |          `0`           |
+| `--health-probe-bind-address`          | he address the probe endpoint binds to                                         |        `:8081`         |
+| `--leader-elect`                       | Enable leader election for controller manager                                  |        `false`         |
+| `--metrics-secure`                     | If set the metrics endpoint is served securely                                 |        `false`         |
+| `--enable-http2`                       | If set, HTTP/2 will be enabled for the metrirs                                 |        `false`         |
+| `--sources-time-to-resync-informers`   | Interval to resynchronize all resources in the informers                       |         `60s`          |
+| `--sources-time-to-reconcile-watchers` | Time between each reconciliation loop of the watchers                          |         `10s`          |
+| `--sources-time-to-ack-watcher`        | Wait time before marking a watcher as acknowledged (ACK) after it starts       |          `2s`          |
+| `--webhook-client-hostname`            | The hostname used by Kubernetes when calling the webhooks server               | `webhooks.admitik.svc` |
+| `--webhook-client-port`                | The port used by Kubernetes when calling the webhooks server                   |        `10250`         |
+| `--webhook-client-timeout`             | The seconds until timout waited by Kubernetes when calling the webhooks server |          `10`          |
+| `--webhook-server-port`                | The port where the webhooks server listens                                     |        `10250`         |
+| `--webhook-server-path`                | The path where the webhooks server listens                                     |      `/validate`       |
+| `--webhook-server-ca`                  | The CA bundle to use for the webhooks server                                   |          `-`           |
+| `--webhook-server-certificate`         | The Certificate used by webhooks server                                        |          `-`           |
+| `--webhook-server-private-key`         | The Private Key used by webhooks server                                        |          `-`           |
 
 
 ## Examples

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -320,7 +320,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Init a controller in charge of launching watchers TODO
+	// Init SourcesController.
+	// This controller is in charge of launching watchers to cache sources expressed in some CRs in background.
+	// This way we avoid retrieving them from Kubernetes on each request to the Admission/Mutation controllers.
 	sourcesController := sources.SourcesController{
 		Client: globals.Application.KubeRawClient,
 		Options: sources.SourcesControllerOptions{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,6 +72,10 @@ func main() {
 	var enableHTTP2 bool
 
 	// Custom flags from here
+	var sourcesTimeToResyncInformers time.Duration
+	var sourcesTimeToReconcileWatchers time.Duration
+	var sourcesTimeToAckWatcher time.Duration
+
 	var webhooksClientHostname string
 	var webhooksClientPort int
 	var webhooksClientTimeout int
@@ -97,6 +101,13 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 
 	// Custom flags from here
+	flag.DurationVar(&sourcesTimeToResyncInformers, "sources-time-to-resync-informers", 60*time.Second,
+		"Interval to resynchronize all resources in the informers")
+	flag.DurationVar(&sourcesTimeToReconcileWatchers, "sources-time-to-reconcile-watchers", 10*time.Second,
+		"Time between each reconciliation loop of the watchers")
+	flag.DurationVar(&sourcesTimeToAckWatcher, "sources-time-to-ack-watcher", 2*time.Second,
+		"Wait time before marking a watcher as acknowledged (ACK) after it starts")
+
 	flag.StringVar(&webhooksClientHostname, "webhook-client-hostname", "webhooks.admitik.svc",
 		"The hostname used by Kubernetes when calling the webhooks server")
 	flag.IntVar(&webhooksClientPort, "webhook-client-port", 10250,
@@ -326,9 +337,9 @@ func main() {
 	sourcesController := sources.SourcesController{
 		Client: globals.Application.KubeRawClient,
 		Options: sources.SourcesControllerOptions{
-			InformerDurationToResync:              60 * time.Second,
-			WatchersDurationBetweenReconcileLoops: 10 * time.Second,
-			WatcherDurationToAck:                  2 * time.Second,
+			InformerDurationToResync:              sourcesTimeToResyncInformers,
+			WatchersDurationBetweenReconcileLoops: sourcesTimeToReconcileWatchers,
+			WatcherDurationToAck:                  sourcesTimeToAckWatcher,
 		},
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	coreLog "log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -332,6 +333,23 @@ func main() {
 
 	setupLog.Info("starting sources controller")
 	go sourcesController.Start(globals.Application.Context)
+
+	go func() {
+		err = sourcesController.SyncWatchers([]sources.ResourceTypeName{
+			"/v1/namespaces//",
+			"gateway.networking.k8s.io/v1/httproutes//"})
+		if err != nil {
+			coreLog.Printf("error syncing watchers: %s", err.Error())
+		}
+
+		time.Sleep(5 * time.Second)
+
+		err = sourcesController.SyncWatchers([]sources.ResourceTypeName{
+			"gateway.networking.k8s.io/v1/httproutes//"})
+		if err != nil {
+			coreLog.Printf("error syncing watchers: %s", err.Error())
+		}
+	}()
 
 	// Init primary controller
 	// ATTENTION: This controller may be replaced by a custom one in the future doing the same tasks

--- a/internal/admission/controller.go
+++ b/internal/admission/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package xyz
+package admission
 
 import (
 	"context"
@@ -32,12 +32,12 @@ import (
 const (
 
 	//
-	controllerContextFinishedMessage = "xyz.WorkloadController finished by context"
+	controllerContextFinishedMessage = "admission.AdmissionController finished by context"
 )
 
-// WorkloadControllerOptions represents available options that can be passed
-// to WorkloadController on start
-type WorkloadControllerOptions struct {
+// AdmissionControllerOptions represents available options that can be passed
+// to AdmissionController on start
+type AdmissionControllerOptions struct {
 	//
 	ServerAddr string
 	ServerPort int
@@ -48,19 +48,19 @@ type WorkloadControllerOptions struct {
 	TLSPrivateKey  string
 }
 
-// WorkloadController represents the controller that triggers parallel threads.
+// AdmissionController represents the controller that triggers parallel threads.
 // These threads process coming events against the conditions defined in Notification CRs
 // Each thread is a watcher in charge of a group of resources GVRNN (Group + Version + Resource + Namespace + Name)
-type WorkloadController struct {
+type AdmissionController struct {
 	Client client.Client
 
 	//
-	Options WorkloadControllerOptions
+	Options AdmissionControllerOptions
 }
 
-// Start launches the XYZ.WorkloadController and keeps it alive
+// Start launches the XYZ.AdmissionController and keeps it alive
 // It kills the controller on application context death, and rerun the process when failed
-func (r *WorkloadController) Start(ctx context.Context) {
+func (r *AdmissionController) Start(ctx context.Context) {
 	logger := log.FromContext(ctx)
 
 	for {
@@ -79,7 +79,7 @@ func (r *WorkloadController) Start(ctx context.Context) {
 }
 
 // runWebserver prepares and runs the HTTP server
-func (r *WorkloadController) runWebserver() (err error) {
+func (r *AdmissionController) runWebserver() (err error) {
 
 	customServer := NewHttpServer()
 

--- a/internal/admission/controller.go
+++ b/internal/admission/controller.go
@@ -58,7 +58,7 @@ type AdmissionController struct {
 	Options AdmissionControllerOptions
 }
 
-// Start launches the XYZ.AdmissionController and keeps it alive
+// Start launches the AdmissionController and keeps it alive
 // It kills the controller on application context death, and rerun the process when failed
 func (r *AdmissionController) Start(ctx context.Context) {
 	logger := log.FromContext(ctx)

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -1,4 +1,4 @@
-package xyz
+package admission
 
 import (
 	"context"

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package admission
 
 import (
@@ -9,10 +25,12 @@ import (
 	"slices"
 	"time"
 
+	//
 	"freepik.com/admitik/api/v1alpha1"
 	"freepik.com/admitik/internal/globals"
 	"freepik.com/admitik/internal/template"
 
+	//
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"

--- a/internal/admission/utils.go
+++ b/internal/admission/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package admission
 
 import (

--- a/internal/admission/utils.go
+++ b/internal/admission/utils.go
@@ -1,4 +1,4 @@
-package xyz
+package admission
 
 import (
 	"errors"

--- a/internal/certificates/certificates.go
+++ b/internal/certificates/certificates.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package certificates
 
 import (

--- a/internal/controller/clusteradmissionpolicy_status.go
+++ b/internal/controller/clusteradmissionpolicy_status.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/internal/controller/commons.go
+++ b/internal/controller/commons.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/internal/globals/conditions.go
+++ b/internal/globals/conditions.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package globals
 
 import (

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package globals
 
 import (

--- a/internal/globals/pools.go
+++ b/internal/globals/pools.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package globals
 
 import "freepik.com/admitik/api/v1alpha1"

--- a/internal/globals/types.go
+++ b/internal/globals/types.go
@@ -11,6 +11,7 @@ import (
 
 	//
 	"freepik.com/admitik/api/v1alpha1"
+	"freepik.com/admitik/internal/sources"
 )
 
 // ClusterAdmissionPolicyPoolT represents TODO
@@ -26,16 +27,13 @@ type applicationT struct {
 	// Context TODO
 	Context context.Context
 
-	// KubeRawClient TODO
-	KubeRawClient *dynamic.DynamicClient
-
-	// KubeRawCoreClient TODO
+	// Kubernetes clients
+	KubeRawClient     *dynamic.DynamicClient
 	KubeRawCoreClient *kubernetes.Clientset
 
 	//
-	ClusterAdmissionPolicyPool ClusterAdmissionPolicyPoolT
+	SourceController *sources.SourcesController
 
-	// WatcherPool TODO
-	//WatcherPool map[ResourceTypeName]ResourceTypeWatcherT
-	//WatcherPool *sources.WatcherPoolT
+	//
+	ClusterAdmissionPolicyPool ClusterAdmissionPolicyPoolT
 }

--- a/internal/globals/types.go
+++ b/internal/globals/types.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	//
+
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
@@ -33,4 +34,8 @@ type applicationT struct {
 
 	//
 	ClusterAdmissionPolicyPool ClusterAdmissionPolicyPoolT
+
+	// WatcherPool TODO
+	//WatcherPool map[ResourceTypeName]ResourceTypeWatcherT
+	//WatcherPool *sources.WatcherPoolT
 }

--- a/internal/globals/types.go
+++ b/internal/globals/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package globals
 
 import (
@@ -5,7 +21,6 @@ import (
 	"sync"
 
 	//
-
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 

--- a/internal/globals/utils.go
+++ b/internal/globals/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package globals
 
 import (
@@ -5,12 +21,12 @@ import (
 	//
 	"os"
 
+	//
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
-	//
 )
 
 // NewKubernetesClient return a new Kubernetes Dynamic client from client-go SDK

--- a/internal/sources/controller.go
+++ b/internal/sources/controller.go
@@ -53,7 +53,7 @@ type SourcesController struct {
 func (r *SourcesController) init() {
 	r.WatcherPool = WatcherPoolT{
 		Mutex: &sync.RWMutex{},
-		Pool:  map[ResourceTypeName]*ResourceTypeWatcherT{},
+		Pool:  map[resourceTypeName]*ResourceTypeWatcherT{},
 	}
 }
 
@@ -113,7 +113,7 @@ func (r *SourcesController) reconcileWatchers(ctx context.Context) {
 }
 
 // watchType launches a watcher for a certain resource type, and trigger processing for each entering resource event
-func (r *SourcesController) watchType(ctx context.Context, watchedType ResourceTypeName) {
+func (r *SourcesController) watchType(ctx context.Context, watchedType resourceTypeName) {
 
 	logger := log.FromContext(ctx)
 

--- a/internal/sources/controller.go
+++ b/internal/sources/controller.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sources
 
 import (

--- a/internal/sources/controller.go
+++ b/internal/sources/controller.go
@@ -1,0 +1,196 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	//
+
+	//
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// SourcesControllerOptions TODO
+type SourcesControllerOptions struct {
+
+	// Duration to wait until resync all the objects
+	InformerDurationToResync time.Duration
+
+	// WatchersDurationBetweenReconcileLoops is the duration to wait between the moment
+	// of launching watchers, and repeating this process (avoid the spam, mate)
+	WatchersDurationBetweenReconcileLoops time.Duration
+
+	// WatcherDurationToAck is the duration before checking whether a watcher
+	// is started or not during watchers' reconciling process
+	WatcherDurationToAck time.Duration
+}
+
+// SourcesControllerOptions represents the controller that triggers parallel watchers.
+// These watchers are in charge of maintaining the pool of sources asked by the user in ClusterAdmissionPolicy objects.
+// A source group is represented by GVRNN (Group + Version + Resource + Namespace + Name)
+type SourcesController struct {
+	// Kubernetes clients
+	Client *dynamic.DynamicClient
+
+	// options to modify the behavior of this SourcesController
+	Options SourcesControllerOptions
+
+	// Carried stuff
+	WatcherPool WatcherPoolT
+}
+
+// Start launches the SourcesController and keeps it alive
+// It kills the controller on application context death, and rerun the process when failed
+func (r *SourcesController) Start(ctx context.Context) {
+	logger := log.FromContext(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("SourcesController finished by context")
+			return
+		default:
+			logger.Info("Starting SourcesController")
+			r.reconcileWatchers(ctx)
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// reconcileWatchers launches a parallel process that launches
+// watchers for resource types defined into the WatcherPool
+func (r *SourcesController) reconcileWatchers(ctx context.Context) {
+	logger := log.FromContext(ctx)
+
+	for resourceType, resourceTypeWatcher := range r.WatcherPool.Pool {
+
+		// TODO: Is this really needed or useful?
+		// Check the existence of the resourceType into the WatcherPool.
+		// Remember the controller.ClusterAdmissionPolicyController can remove watchers on garbage collection
+		if _, resourceTypeFound := r.WatcherPool.Pool[resourceType]; !resourceTypeFound {
+			continue
+		}
+
+		// Prevent blocked watchers from being started.
+		// Remember the controller.ClusterAdmissionPolicyController blocks them during garbage collection
+		if *resourceTypeWatcher.Blocked {
+			continue
+		}
+
+		if !*resourceTypeWatcher.Started {
+			go r.watchType(ctx, resourceType)
+
+			// Wait for the resourceType watcher to ACK itself into WatcherPool
+			time.Sleep(r.Options.WatcherDurationToAck)
+			if *(r.WatcherPool.Pool[resourceType].Started) == false {
+				logger.Info(fmt.Sprintf("Impossible to start watcher for resource type: %s", resourceType))
+			}
+		}
+
+		// Wait a bit to reduce the spam to machine resources
+		time.Sleep(r.Options.WatchersDurationBetweenReconcileLoops)
+	}
+}
+
+// watchType launches a watcher for a certain resource type, and trigger processing for each entering resource event
+func (r *SourcesController) watchType(ctx context.Context, watchedType ResourceTypeName) {
+
+	logger := log.FromContext(ctx)
+
+	logger.Info(fmt.Sprintf("Watcher for '%s' has been started", watchedType))
+
+	// Set ACK flag for watcher launching into the WatcherPool
+	*(r.WatcherPool.Pool[watchedType].Started) = true
+	defer func() {
+		*(r.WatcherPool.Pool[watchedType].Started) = false
+	}()
+
+	// Extract GVR + Namespace + Name from watched type:
+	// {group}/{version}/{resource}/{namespace}/{name}
+	GVRNN := strings.Split(string(watchedType), "/")
+	if len(GVRNN) != 5 {
+		logger.Info("Failed to parse GVR from resourceType. Does it look like {group}/{version}/{resource}?")
+		return
+	}
+	resourceGVR := schema.GroupVersionResource{
+		Group:    GVRNN[0],
+		Version:  GVRNN[1],
+		Resource: GVRNN[2],
+	}
+
+	// Include the namespace when defined by the user (used as filter)
+	namespace := corev1.NamespaceAll
+	if GVRNN[3] != "" {
+		namespace = GVRNN[3]
+	}
+
+	// Include the name when defined by the user (used as filter)
+	name := GVRNN[4]
+
+	var listOptionsFunc dynamicinformer.TweakListOptionsFunc = func(options *metav1.ListOptions) {}
+	if name != "" {
+		listOptionsFunc = func(options *metav1.ListOptions) {
+			options.FieldSelector = "metadata.name=" + name
+		}
+	}
+
+	// Listen to stop signal to kill this watcher just in case it's needed
+	stopCh := make(chan struct{})
+
+	go func() {
+		<-*(r.WatcherPool.Pool[watchedType].StopSignal)
+		close(stopCh)
+		logger.Info(fmt.Sprintf("Watcher for resource type '%s' killed by StopSignal", watchedType))
+	}()
+
+	// Define our informer
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(r.Client,
+		r.Options.InformerDurationToResync, namespace, listOptionsFunc)
+
+	// Create an informer. This is a special type of client-go watcher that includes
+	// mechanisms to hide disconnections, handle reconnections, and cache watched objects
+	informer := factory.ForResource(resourceGVR).Informer()
+
+	// Register functions to handle different types of events
+	handlers := cache.ResourceEventHandlerFuncs{
+
+		AddFunc: func(eventObject interface{}) {
+			convertedObject := eventObject.(*unstructured.Unstructured)
+			r.CreateWatcherResource(watchedType, convertedObject)
+		},
+		UpdateFunc: func(_, eventObject interface{}) {
+			convertedObject := eventObject.(*unstructured.Unstructured)
+			objectIndex := r.GetWatcherResourceIndex(watchedType, convertedObject)
+
+			if objectIndex > -1 {
+				r.UpdateWatcherResourceByIndex(watchedType, objectIndex, convertedObject)
+			}
+		},
+		DeleteFunc: func(eventObject interface{}) {
+			convertedObject := eventObject.(*unstructured.Unstructured)
+			objectIndex := r.GetWatcherResourceIndex(watchedType, convertedObject)
+
+			if objectIndex > -1 {
+				r.DeleteWatcherResourceByIndex(watchedType, objectIndex)
+			}
+		},
+	}
+
+	_, err := informer.AddEventHandler(handlers)
+	if err != nil {
+		logger.Error(err, "Error adding handling functions for events to an informer")
+		return
+	}
+
+	informer.Run(stopCh)
+}

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -1,0 +1,40 @@
+package sources
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// TODO
+type ResourceTypeName string
+
+// TODO
+type ResourceTypeWatcherT struct {
+	// Enforce concurrency safety
+	Mutex *sync.Mutex
+
+	// Started represents a flag to know if the watcher is running
+	Started *bool
+
+	// Blocked represents a flag to prevent watcher from starting
+	Blocked *bool
+
+	// StopSignal represents a flag to kill the watcher.
+	// Watcher will be potentially re-launched by SourcesController
+	StopSignal *chan bool
+
+	// Dependants represents the amount of policies
+	// depending on the resources cached by this watcher
+	//Dependants int
+
+	//
+	ResourceList *[]*unstructured.Unstructured
+}
+
+type WatcherPoolT struct {
+	// Enforce concurrency safety
+	Mutex *sync.Mutex
+
+	Pool map[ResourceTypeName]ResourceTypeWatcherT
+}

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sources
 
 import (

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -12,7 +12,7 @@ type ResourceTypeName string
 // TODO
 type ResourceTypeWatcherT struct {
 	// Enforce concurrency safety
-	Mutex *sync.Mutex
+	Mutex *sync.RWMutex
 
 	// Started represents a flag to know if the watcher is running
 	Started *bool
@@ -24,17 +24,13 @@ type ResourceTypeWatcherT struct {
 	// Watcher will be potentially re-launched by SourcesController
 	StopSignal *chan bool
 
-	// Dependants represents the amount of policies
-	// depending on the resources cached by this watcher
-	//Dependants int
-
 	//
-	ResourceList *[]*unstructured.Unstructured
+	ResourceList []*unstructured.Unstructured
 }
 
 type WatcherPoolT struct {
 	// Enforce concurrency safety
-	Mutex *sync.Mutex
+	Mutex *sync.RWMutex
 
-	Pool map[ResourceTypeName]ResourceTypeWatcherT
+	Pool map[ResourceTypeName]*ResourceTypeWatcherT
 }

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -10,7 +10,7 @@ import (
 type resourceTypeName string
 
 // TODO
-type ResourceTypeWatcherT struct {
+type resourceTypeWatcherT struct {
 	// Enforce concurrency safety
 	Mutex *sync.RWMutex
 
@@ -32,5 +32,5 @@ type WatcherPoolT struct {
 	// Enforce concurrency safety
 	Mutex *sync.RWMutex
 
-	Pool map[resourceTypeName]*ResourceTypeWatcherT
+	Pool map[resourceTypeName]*resourceTypeWatcherT
 }

--- a/internal/sources/types.go
+++ b/internal/sources/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TODO
-type ResourceTypeName string
+type resourceTypeName string
 
 // TODO
 type ResourceTypeWatcherT struct {
@@ -32,5 +32,5 @@ type WatcherPoolT struct {
 	// Enforce concurrency safety
 	Mutex *sync.RWMutex
 
-	Pool map[ResourceTypeName]*ResourceTypeWatcherT
+	Pool map[resourceTypeName]*ResourceTypeWatcherT
 }

--- a/internal/sources/utils.go
+++ b/internal/sources/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sources
 
 import (

--- a/internal/sources/utils.go
+++ b/internal/sources/utils.go
@@ -2,16 +2,20 @@ package sources
 
 import (
 	"errors"
+	"fmt"
+	"slices"
 	"sync"
 	"time"
 
-	//
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	//
 )
 
-// TODO
-func (r *SourcesController) StartWatcher(watcherType ResourceTypeName) {
+// prepareWatcher scaffolds a new watcher in the WatchedPool.
+// This prepares the field for later watchers' reconciliation process.
+// That process will create the real Kubernetes informer for this object
+// This function is not responsible for blocking the pool before being executed
+func (r *SourcesController) prepareWatcher(watcherType ResourceTypeName) {
 
 	var initialStartedState bool = false
 	var initialBlockedState bool = false
@@ -31,8 +35,87 @@ func (r *SourcesController) StartWatcher(watcherType ResourceTypeName) {
 	}
 }
 
+// disableWatcher disables a watcher from the WatcherPool.
+// It first blocks the watcher to prevent it from being started by any controller,
+// then, the watcher is stopped and resources are deleted.
+// This function is not responsible for blocking the pool before being executed
+func (r *SourcesController) disableWatcher(watcherType ResourceTypeName) (result bool) {
+
+	// 1. Prevent watcher from being started again
+	*r.WatcherPool.Pool[watcherType].Blocked = true
+
+	// 2. Stop the watcher
+	*r.WatcherPool.Pool[watcherType].StopSignal <- true
+
+	// 3. Wait for the watcher to be stopped. Return false on failure
+	stoppedWatcher := false
+	for i := 0; i < 10; i++ {
+		if !*r.WatcherPool.Pool[watcherType].Started {
+			stoppedWatcher = true
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if !stoppedWatcher {
+		return false
+	}
+
+	*r.WatcherPool.Pool[watcherType].ResourceList = []*unstructured.Unstructured{}
+	return true
+}
+
+// SyncWatchers ensures the WatcherPool matches the desired state.
+//
+// Given a list of desired watchers in GVRNN format (Group/Version/Resource/Namespace/Name),
+// this function creates missing watchers, ensures active ones are unblocked, and removes
+// any watchers that are no longer needed.
+func (r *SourcesController) SyncWatchers(watcherTypeList []ResourceTypeName) (err error) {
+	r.WatcherPool.Mutex.Lock()
+	defer r.WatcherPool.Mutex.Unlock()
+
+	// 1. Keep existing watchers (or create them) for desired resources types
+	for _, desiredPoolName := range watcherTypeList {
+
+		// Scaffold new watchers when they does not exist
+		if _, exists := r.WatcherPool.Pool[desiredPoolName]; !exists {
+			r.prepareWatcher(desiredPoolName)
+			continue
+		}
+
+		// Ensure already existing ones are NOT blocked
+		r.WatcherPool.Pool[desiredPoolName].Mutex.Lock()
+		if !*r.WatcherPool.Pool[desiredPoolName].Started {
+			falseVal := false
+			*r.WatcherPool.Pool[desiredPoolName].Blocked = falseVal
+		}
+		r.WatcherPool.Pool[desiredPoolName].Mutex.Unlock()
+	}
+
+	// 2. Clean up unneeded watchers
+	for existingPoolName, existingPool := range r.WatcherPool.Pool {
+
+		if !slices.Contains(watcherTypeList, existingPoolName) {
+			existingPool.Mutex.Lock()
+
+			watcherDisabled := r.disableWatcher(existingPoolName)
+			if !watcherDisabled {
+				err = errors.Join(fmt.Errorf("impossible to disable watcher for: %s", existingPoolName))
+			}
+
+			existingPool.Mutex.Unlock()
+
+			// Clean up the watcher from the pool
+			delete(r.WatcherPool.Pool, existingPoolName)
+			continue
+		}
+	}
+
+	return err
+}
+
 // TODO
-func (r *SourcesController) CreateWatcherResource(watcherType ResourceTypeName, resource *unstructured.Unstructured) {
+func (r *SourcesController) createWatcherResource(watcherType ResourceTypeName, resource *unstructured.Unstructured) {
 
 	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
 
@@ -44,7 +127,7 @@ func (r *SourcesController) CreateWatcherResource(watcherType ResourceTypeName, 
 }
 
 // TODO
-func (r *SourcesController) GetWatcherResourceIndex(watcherType ResourceTypeName, resource *unstructured.Unstructured) (result int) {
+func (r *SourcesController) getWatcherResourceIndex(watcherType ResourceTypeName, resource *unstructured.Unstructured) (result int) {
 
 	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
 
@@ -60,7 +143,7 @@ func (r *SourcesController) GetWatcherResourceIndex(watcherType ResourceTypeName
 }
 
 // TODO
-func (r *SourcesController) UpdateWatcherResourceByIndex(watcherType ResourceTypeName, resourceIndex int, resource *unstructured.Unstructured) {
+func (r *SourcesController) updateWatcherResourceByIndex(watcherType ResourceTypeName, resourceIndex int, resource *unstructured.Unstructured) {
 
 	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
 
@@ -71,7 +154,7 @@ func (r *SourcesController) UpdateWatcherResourceByIndex(watcherType ResourceTyp
 }
 
 // TODO
-func (r *SourcesController) DeleteWatcherResourceByIndex(watcherType ResourceTypeName, resourceIndex int) {
+func (r *SourcesController) deleteWatcherResourceByIndex(watcherType ResourceTypeName, resourceIndex int) {
 
 	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
 
@@ -82,67 +165,3 @@ func (r *SourcesController) DeleteWatcherResourceByIndex(watcherType ResourceTyp
 	// then replace the whole list with it, minus the last.
 	*resourceList = append((*resourceList)[:resourceIndex], (*resourceList)[resourceIndex+1:]...)
 }
-
-// DisableWatcherFromWatcherPool disable a watcher from the WatcherPool.
-// It first blocks the watcher to prevent it from being started by any controller,
-// then blocks the WatcherPool temporary while killing the watcher.
-func (r *SourcesController) DisableWatcherFromWatcherPool(watcherType ResourceTypeName) (result bool, err error) {
-
-	//Application.WatcherPool.Pool[watcherType].Mutex.Lock()
-
-	// 1. Prevent watcher from being started again
-	*r.WatcherPool.Pool[watcherType].Blocked = true
-
-	// 2. Stop the watcher
-	*r.WatcherPool.Pool[watcherType].StopSignal <- true
-
-	//Application.WatcherPool.Pool[watcherType].Mutex.Unlock()
-
-	// 3. Wait for the watcher to be stopped. Return false on failure
-	stoppedWatcher := false
-	for i := 0; i < 10; i++ {
-		if !*r.WatcherPool.Pool[watcherType].Started {
-			stoppedWatcher = true
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	if !stoppedWatcher {
-		return false, errors.New("impossible to stop the watcher")
-	}
-
-	// 4. Delete the watcher from the WatcherPool.Pool
-	//Application.WatcherPool.Mutex.Lock()
-	//delete(Application.WatcherPool.Pool, watcherType)
-	//Application.WatcherPool.Mutex.Unlock()
-
-	//if _, keyFound := Application.WatcherPool.Pool[watcherType]; keyFound {
-	//	return false, errors.New("impossible to delete the watcherType from WatcherPool")
-	//}
-
-	return true, nil
-}
-
-// CleanWatcherPool check the WatcherPool looking for empty watchers to trigger their deletion.
-// This function is intended to be executed on its own, so returns nothing
-// func (r *SourcesController) CleanWatcherPool(ctx context.Context) {
-// 	logger := log.FromContext(ctx)
-
-// 	for watcherType, _ := range r.WatcherPool.Pool {
-
-// 		if len(*r.WatcherPool.Pool[watcherType].ResourceList) != 0 {
-// 			continue
-// 		}
-
-// 		watcherDeleted, err := r.DisableWatcherFromWatcherPool(watcherType)
-// 		if !watcherDeleted {
-// 			logger.WithValues("watcher", watcherType, "error", err).
-// 				Info("watcher was not deleted from WatcherPool")
-// 			continue
-// 		}
-
-// 		logger.WithValues("watcher", watcherType).
-// 			Info("watcher has been deleted from WatcherPool")
-// 	}
-// }

--- a/internal/sources/utils.go
+++ b/internal/sources/utils.go
@@ -1,0 +1,148 @@
+package sources
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	//
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	//
+)
+
+// TODO
+func (r *SourcesController) StartWatcher(watcherType ResourceTypeName) {
+
+	var initialStartedState bool = false
+	var initialBlockedState bool = false
+	var initialResourceListState []*unstructured.Unstructured
+
+	initialStopSignalState := make(chan bool)
+	initialMutexState := sync.Mutex{}
+
+	r.WatcherPool.Pool[watcherType] = ResourceTypeWatcherT{
+		Mutex: &initialMutexState,
+
+		Started:    &initialStartedState,
+		Blocked:    &initialBlockedState,
+		StopSignal: &initialStopSignalState,
+
+		ResourceList: &initialResourceListState,
+	}
+}
+
+// TODO
+func (r *SourcesController) CreateWatcherResource(watcherType ResourceTypeName, resource *unstructured.Unstructured) {
+
+	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
+
+	(r.WatcherPool.Pool[watcherType].Mutex).Lock()
+	defer (r.WatcherPool.Pool[watcherType].Mutex).Unlock()
+
+	temporaryManifest := (*resource).DeepCopy()
+	*resourceList = append(*resourceList, temporaryManifest)
+}
+
+// TODO
+func (r *SourcesController) GetWatcherResourceIndex(watcherType ResourceTypeName, resource *unstructured.Unstructured) (result int) {
+
+	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
+
+	for tmpResourceIndex, tmpResource := range *resourceList {
+
+		if (tmpResource.GetName() == resource.GetName()) &&
+			(tmpResource.GetNamespace() == resource.GetNamespace()) {
+			return tmpResourceIndex
+		}
+	}
+
+	return -1
+}
+
+// TODO
+func (r *SourcesController) UpdateWatcherResourceByIndex(watcherType ResourceTypeName, resourceIndex int, resource *unstructured.Unstructured) {
+
+	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
+
+	(r.WatcherPool.Pool[watcherType].Mutex).Lock()
+	defer (r.WatcherPool.Pool[watcherType].Mutex).Unlock()
+
+	(*resourceList)[resourceIndex] = resource
+}
+
+// TODO
+func (r *SourcesController) DeleteWatcherResourceByIndex(watcherType ResourceTypeName, resourceIndex int) {
+
+	resourceList := r.WatcherPool.Pool[watcherType].ResourceList
+
+	(r.WatcherPool.Pool[watcherType].Mutex).Lock()
+	defer (r.WatcherPool.Pool[watcherType].Mutex).Unlock()
+
+	// Substitute the selected notification object with the last one from the list,
+	// then replace the whole list with it, minus the last.
+	*resourceList = append((*resourceList)[:resourceIndex], (*resourceList)[resourceIndex+1:]...)
+}
+
+// DisableWatcherFromWatcherPool disable a watcher from the WatcherPool.
+// It first blocks the watcher to prevent it from being started by any controller,
+// then blocks the WatcherPool temporary while killing the watcher.
+func (r *SourcesController) DisableWatcherFromWatcherPool(watcherType ResourceTypeName) (result bool, err error) {
+
+	//Application.WatcherPool.Pool[watcherType].Mutex.Lock()
+
+	// 1. Prevent watcher from being started again
+	*r.WatcherPool.Pool[watcherType].Blocked = true
+
+	// 2. Stop the watcher
+	*r.WatcherPool.Pool[watcherType].StopSignal <- true
+
+	//Application.WatcherPool.Pool[watcherType].Mutex.Unlock()
+
+	// 3. Wait for the watcher to be stopped. Return false on failure
+	stoppedWatcher := false
+	for i := 0; i < 10; i++ {
+		if !*r.WatcherPool.Pool[watcherType].Started {
+			stoppedWatcher = true
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if !stoppedWatcher {
+		return false, errors.New("impossible to stop the watcher")
+	}
+
+	// 4. Delete the watcher from the WatcherPool.Pool
+	//Application.WatcherPool.Mutex.Lock()
+	//delete(Application.WatcherPool.Pool, watcherType)
+	//Application.WatcherPool.Mutex.Unlock()
+
+	//if _, keyFound := Application.WatcherPool.Pool[watcherType]; keyFound {
+	//	return false, errors.New("impossible to delete the watcherType from WatcherPool")
+	//}
+
+	return true, nil
+}
+
+// CleanWatcherPool check the WatcherPool looking for empty watchers to trigger their deletion.
+// This function is intended to be executed on its own, so returns nothing
+// func (r *SourcesController) CleanWatcherPool(ctx context.Context) {
+// 	logger := log.FromContext(ctx)
+
+// 	for watcherType, _ := range r.WatcherPool.Pool {
+
+// 		if len(*r.WatcherPool.Pool[watcherType].ResourceList) != 0 {
+// 			continue
+// 		}
+
+// 		watcherDeleted, err := r.DisableWatcherFromWatcherPool(watcherType)
+// 		if !watcherDeleted {
+// 			logger.WithValues("watcher", watcherType, "error", err).
+// 				Info("watcher was not deleted from WatcherPool")
+// 			continue
+// 		}
+
+// 		logger.WithValues("watcher", watcherType).
+// 			Info("watcher has been deleted from WatcherPool")
+// 	}
+// }

--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package template
 
 import (


### PR DESCRIPTION
**Description:**

- **Rename XYZ controller to AdmissionController**
- **Create SourcesController**. This controller maintains as many watchers as requested sources types. Those source types are defined as `{group}/{version}/{resouce}/{namespace}/{name}` 
- **Modify ClusterAdmissionPolicy controller to call sources.SyncWatchers** in the end of each reconcile cycle
- **Modify AdmissionController to get sources from SourcesController**
- Of course, **modify entrypoint to launch SourcesController**
- **Add flags for configurable options of SourcesController**
- **Add new flags documentation** in README

**Out-of-scope:**

- **Put the proper license** header on code files
- **Decouple creation of the ValidatingWebhookConfiguration** object from the SyncAdmissionPool() logic