### PR TITLE
fix: Improve controllers concurrency on replicated environment

### DIFF
--- a/internal/controller/clustermutationpolicy/controller.go
+++ b/internal/controller/clustermutationpolicy/controller.go
@@ -97,8 +97,10 @@ func (r *ClusterMutationPolicyReconciler) Reconcile(ctx context.Context, req ctr
 			}
 
 			// Remove the finalizers on the resource
-			controllerutil.RemoveFinalizer(objectManifest, controller.ResourceFinalizer)
-			err = r.Update(ctx, objectManifest)
+			err = controller.UpdateWithRetry(ctx, r.Client, objectManifest, func(object client.Object) error {
+				controllerutil.RemoveFinalizer(object, controller.ResourceFinalizer)
+				return nil
+			})
 			if err != nil {
 				logger.Info(fmt.Sprintf(controller.ResourceFinalizersUpdateError, controller.ClusterMutationPolicyResourceType, req.Name, err.Error()))
 			}
@@ -110,8 +112,10 @@ func (r *ClusterMutationPolicyReconciler) Reconcile(ctx context.Context, req ctr
 
 	// 4. Add finalizer to the resource
 	if !controllerutil.ContainsFinalizer(objectManifest, controller.ResourceFinalizer) {
-		controllerutil.AddFinalizer(objectManifest, controller.ResourceFinalizer)
-		err = r.Update(ctx, objectManifest)
+		err = controller.UpdateWithRetry(ctx, r.Client, objectManifest, func(object client.Object) error {
+			controllerutil.AddFinalizer(objectManifest, controller.ResourceFinalizer)
+			return nil
+		})
 		if err != nil {
 			return result, err
 		}
@@ -119,7 +123,9 @@ func (r *ClusterMutationPolicyReconciler) Reconcile(ctx context.Context, req ctr
 
 	// 5. Update the status before the requeue
 	defer func() {
-		err = r.Status().Update(ctx, objectManifest)
+		err = controller.UpdateWithRetry(ctx, r.Client, objectManifest, func(object client.Object) error {
+			return nil
+		})
 		if err != nil {
 			logger.Info(fmt.Sprintf(controller.ResourceConditionUpdateError, controller.ClusterMutationPolicyResourceType, req.Name, err.Error()))
 		}

--- a/internal/controller/clustervalidationpolicy/controller.go
+++ b/internal/controller/clustervalidationpolicy/controller.go
@@ -96,8 +96,10 @@ func (r *ClusterValidationPolicyReconciler) Reconcile(ctx context.Context, req c
 			}
 
 			// Remove the finalizers on the resource
-			controllerutil.RemoveFinalizer(objectManifest, controller.ResourceFinalizer)
-			err = r.Update(ctx, objectManifest)
+			err = controller.UpdateWithRetry(ctx, r.Client, objectManifest, func(object client.Object) error {
+				controllerutil.RemoveFinalizer(object, controller.ResourceFinalizer)
+				return nil
+			})
 			if err != nil {
 				logger.Info(fmt.Sprintf(controller.ResourceFinalizersUpdateError, controller.ClusterValidationPolicyResourceType, req.Name, err.Error()))
 			}
@@ -109,8 +111,10 @@ func (r *ClusterValidationPolicyReconciler) Reconcile(ctx context.Context, req c
 
 	// 4. Add finalizer to the resource
 	if !controllerutil.ContainsFinalizer(objectManifest, controller.ResourceFinalizer) {
-		controllerutil.AddFinalizer(objectManifest, controller.ResourceFinalizer)
-		err = r.Update(ctx, objectManifest)
+		err = controller.UpdateWithRetry(ctx, r.Client, objectManifest, func(object client.Object) error {
+			controllerutil.AddFinalizer(objectManifest, controller.ResourceFinalizer)
+			return nil
+		})
 		if err != nil {
 			return result, err
 		}
@@ -118,7 +122,9 @@ func (r *ClusterValidationPolicyReconciler) Reconcile(ctx context.Context, req c
 
 	// 5. Update the status before the requeue
 	defer func() {
-		err = r.Status().Update(ctx, objectManifest)
+		err = controller.UpdateWithRetry(ctx, r.Client, objectManifest, func(object client.Object) error {
+			return nil
+		})
 		if err != nil {
 			logger.Info(fmt.Sprintf(controller.ResourceConditionUpdateError, controller.ClusterValidationPolicyResourceType, req.Name, err.Error()))
 		}

--- a/internal/controller/commons.go
+++ b/internal/controller/commons.go
@@ -19,17 +19,17 @@ package controller
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"net/url"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 	"time"
 
 	//
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (


### PR DESCRIPTION
**Changes**

- Implement _exponential backoff retries_ and _three-way-merge_ for controllers on `update` operations

**Reasons**

At this moment, all running instances are completely equal, this means they are not having a leader performing actions, but all instances want to perform them. This guarantee that your policies are always applied as expected.

This can cause a race condition against the API server when updating the status field of policies, or the finalizers. To avoid this, two ways are implementable: this one (nowadays), and server-side-apply (will be implemented in the future)

**In the future we will:**
- Implement Server Side Apply instead of current strategy to reduce the pressure on Kube API server
- Give the posibility to chose a leader for those components able to work on that way (it makes sense for GenerationController, but it doesn't for AdmissionServer, for example)