### PR TITLE
feat: Add StrategicMerge engine as patch type

### DIFF
--- a/api/v1alpha1/clustergenerationpolicy_types.go
+++ b/api/v1alpha1/clustergenerationpolicy_types.go
@@ -40,13 +40,30 @@ type ObjectT struct {
 type ClusterGenerationPolicySpec struct {
 	OverwriteExisting bool `json:"overwriteExisting,omitempty"`
 
-	//
+	// WatchedResources represents a list of resource-groups that will be watched to be evaluated
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=version
+	// +listMapKey=resource
+	// +listMapKey=name
+	// +listMapKey=namespace
 	WatchedResources []ResourceGroupT `json:"watchedResources"`
-	Sources          []ResourceGroupT `json:"sources"`
 
-	//
+	// Sources represents a list of extra resource-groups to watch and inject in templates
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=version
+	// +listMapKey=resource
+	// +listMapKey=name
+	// +listMapKey=namespace
+	Sources []ResourceGroupT `json:"sources"`
+
+	// Conditions represents a list of conditions that must be passed to meet the policy
+	// +listType=map
+	// +listMapKey=name
 	Conditions []ConditionT `json:"conditions"`
-	Object     ObjectT      `json:"object"`
+
+	Object ObjectT `json:"object"`
 }
 
 // ClusterGenerationPolicyStatus defines the observed state of ClusterGenerationPolicy

--- a/api/v1alpha1/clustermutationpolicy_types.go
+++ b/api/v1alpha1/clustermutationpolicy_types.go
@@ -34,13 +34,29 @@ type PatchT struct {
 
 // ClusterMutationPolicySpec defines the desired state of ClusterMutationPolicy
 type ClusterMutationPolicySpec struct {
-	//
-	InterceptedResources []AdmissionResourceGroupT `json:"interceptedResources"`
-	Sources              []ResourceGroupT          `json:"sources"`
 
-	//
+	// InterceptedResources represents a list of resource-groups that will be sent to the admissions server to be evaluated
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=version
+	// +listMapKey=resource
+	InterceptedResources []AdmissionResourceGroupT `json:"interceptedResources"`
+
+	// Sources represents a list of extra resource-groups to watch and inject in templates
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=version
+	// +listMapKey=resource
+	// +listMapKey=name
+	// +listMapKey=namespace
+	Sources []ResourceGroupT `json:"sources"`
+
+	// Conditions represents a list of conditions that must be passed to meet the policy
+	// +listType=map
+	// +listMapKey=name
 	Conditions []ConditionT `json:"conditions"`
-	Patch      PatchT       `json:"patch"`
+
+	Patch PatchT `json:"patch"`
 }
 
 // ClusterMutationPolicyStatus defines the observed state of ClusterMutationPolicy

--- a/api/v1alpha1/clustervalidationpolicy_types.go
+++ b/api/v1alpha1/clustervalidationpolicy_types.go
@@ -34,13 +34,28 @@ type MessageT struct {
 type ClusterValidationPolicySpec struct {
 	FailureAction string `json:"failureAction,omitempty"`
 
-	//
+	// InterceptedResources represents a list of resource-groups that will be sent to the admissions server to be evaluated
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=version
+	// +listMapKey=resource
 	InterceptedResources []AdmissionResourceGroupT `json:"interceptedResources"`
-	Sources              []ResourceGroupT          `json:"sources"`
 
-	//
+	// Sources represents a list of extra resource-groups to watch and inject in templates
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=version
+	// +listMapKey=resource
+	// +listMapKey=name
+	// +listMapKey=namespace
+	Sources []ResourceGroupT `json:"sources"`
+
+	// Conditions represents a list of conditions that must be passed to meet the policy
+	// +listType=map
+	// +listMapKey=name
 	Conditions []ConditionT `json:"conditions"`
-	Message    MessageT     `json:"message"`
+
+	Message MessageT `json:"message"`
 }
 
 // ClusterValidationPolicyStatus defines the observed state of ClusterValidationPolicy

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -21,22 +21,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ResourceGroupT represents a group of resources
+// ResourceGroupT represents a resource-group that will be watched to be evaluated
 type ResourceGroupT struct {
 	metav1.GroupVersionResource `json:",inline"`
 
-	Name      string `json:"name,omitempty"`
+	// +default=""
+	// +kubebuilder:default=""
+	Name string `json:"name,omitempty"`
+
+	// +default=""
+	// +kubebuilder:default=""
 	Namespace string `json:"namespace,omitempty"`
 }
 
-// AdmissionResourceGroupT represents a group of resources from Admission point of view
+// AdmissionResourceGroupT represents a resource-group that will be sent to the admissions server to be evaluated
 type AdmissionResourceGroupT struct {
 	metav1.GroupVersionResource `json:",inline"`
 
+	// Conditions represents a list of conditions that must be passed to meet the policy
+	// +listType=set
 	Operations []admissionV1.OperationType `json:"operations"`
 }
 
-// ConditionT represents a canonical Kubernetes status condition for a resource
+// ConditionT represents a condition that must be passed to meet the policy
 type ConditionT struct {
 	Name   string `json:"name"`
 	Engine string `json:"engine,omitempty"`

--- a/charts/admitik/Chart.yaml
+++ b/charts/admitik/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 description: >-
   A Helm chart for Admitik, an admission controller for Kubernetes
   that allow resources entrance if conditions are met (realtime)
-version: 1.4.3
-appVersion: "1.4.3" # application version
+version: 1.5.0
+appVersion: "1.5.0" # application version
 kubeVersion: ">=1.22.0-0" # kubernetes version
 home: https://github.com/freepik-company/admitik
 sources:

--- a/charts/admitik/crds/admitik.freepik.com_clustergenerationpolicies.yaml
+++ b/charts/admitik/crds/admitik.freepik.com_clustergenerationpolicies.yaml
@@ -42,9 +42,11 @@ spec:
               ClusterGenerationPolicy
             properties:
               conditions:
+                description: Conditions represents a list of conditions that must
+                  be passed to meet the policy
                 items:
-                  description: ConditionT represents a canonical Kubernetes status
-                    condition for a resource
+                  description: ConditionT represents a condition that must be passed
+                    to meet the policy
                   properties:
                     engine:
                       type: string
@@ -60,6 +62,9 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               object:
                 description: ObjectT TODO
                 properties:
@@ -83,14 +88,19 @@ spec:
               overwriteExisting:
                 type: boolean
               sources:
+                description: Sources represents a list of extra resource-groups to
+                  watch and inject in templates
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -102,15 +112,27 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
               watchedResources:
+                description: WatchedResources represents a list of resource-groups
+                  that will be watched to be evaluated
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -122,6 +144,13 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
             required:
             - conditions
             - object

--- a/charts/admitik/crds/admitik.freepik.com_clustermutationpolicies.yaml
+++ b/charts/admitik/crds/admitik.freepik.com_clustermutationpolicies.yaml
@@ -41,9 +41,11 @@ spec:
             description: ClusterMutationPolicySpec defines the desired state of ClusterMutationPolicy
             properties:
               conditions:
+                description: Conditions represents a list of conditions that must
+                  be passed to meet the policy
                 items:
-                  description: ConditionT represents a canonical Kubernetes status
-                    condition for a resource
+                  description: ConditionT represents a condition that must be passed
+                    to meet the policy
                   properties:
                     engine:
                       type: string
@@ -59,18 +61,26 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               interceptedResources:
+                description: InterceptedResources represents a list of resource-groups
+                  that will be sent to the admissions server to be evaluated
                 items:
-                  description: AdmissionResourceGroupT represents a group of resources
-                    from Admission point of view
+                  description: AdmissionResourceGroupT represents a resource-group
+                    that will be sent to the admissions server to be evaluated
                   properties:
                     group:
                       type: string
                     operations:
+                      description: Conditions represents a list of conditions that
+                        must be passed to meet the policy
                       items:
                         description: OperationType specifies an operation for a request.
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     resource:
                       type: string
                     version:
@@ -82,6 +92,11 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                x-kubernetes-list-type: map
               patch:
                 properties:
                   engine:
@@ -95,14 +110,19 @@ spec:
                 - type
                 type: object
               sources:
+                description: Sources represents a list of extra resource-groups to
+                  watch and inject in templates
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -114,6 +134,13 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
             required:
             - conditions
             - interceptedResources

--- a/charts/admitik/crds/admitik.freepik.com_clustervalidationpolicies.yaml
+++ b/charts/admitik/crds/admitik.freepik.com_clustervalidationpolicies.yaml
@@ -42,9 +42,11 @@ spec:
               ClusterValidationPolicy
             properties:
               conditions:
+                description: Conditions represents a list of conditions that must
+                  be passed to meet the policy
                 items:
-                  description: ConditionT represents a canonical Kubernetes status
-                    condition for a resource
+                  description: ConditionT represents a condition that must be passed
+                    to meet the policy
                   properties:
                     engine:
                       type: string
@@ -60,20 +62,28 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               failureAction:
                 type: string
               interceptedResources:
+                description: InterceptedResources represents a list of resource-groups
+                  that will be sent to the admissions server to be evaluated
                 items:
-                  description: AdmissionResourceGroupT represents a group of resources
-                    from Admission point of view
+                  description: AdmissionResourceGroupT represents a resource-group
+                    that will be sent to the admissions server to be evaluated
                   properties:
                     group:
                       type: string
                     operations:
+                      description: Conditions represents a list of conditions that
+                        must be passed to meet the policy
                       items:
                         description: OperationType specifies an operation for a request.
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     resource:
                       type: string
                     version:
@@ -85,6 +95,11 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                x-kubernetes-list-type: map
               message:
                 properties:
                   engine:
@@ -95,14 +110,19 @@ spec:
                 - template
                 type: object
               sources:
+                description: Sources represents a list of extra resource-groups to
+                  watch and inject in templates
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -114,6 +134,13 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
             required:
             - conditions
             - interceptedResources

--- a/config/crd/bases/admitik.freepik.com_clustergenerationpolicies.yaml
+++ b/config/crd/bases/admitik.freepik.com_clustergenerationpolicies.yaml
@@ -42,9 +42,11 @@ spec:
               ClusterGenerationPolicy
             properties:
               conditions:
+                description: Conditions represents a list of conditions that must
+                  be passed to meet the policy
                 items:
-                  description: ConditionT represents a canonical Kubernetes status
-                    condition for a resource
+                  description: ConditionT represents a condition that must be passed
+                    to meet the policy
                   properties:
                     engine:
                       type: string
@@ -60,6 +62,9 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               object:
                 description: ObjectT TODO
                 properties:
@@ -83,14 +88,19 @@ spec:
               overwriteExisting:
                 type: boolean
               sources:
+                description: Sources represents a list of extra resource-groups to
+                  watch and inject in templates
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -102,15 +112,27 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
               watchedResources:
+                description: WatchedResources represents a list of resource-groups
+                  that will be watched to be evaluated
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -122,6 +144,13 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
             required:
             - conditions
             - object

--- a/config/crd/bases/admitik.freepik.com_clustermutationpolicies.yaml
+++ b/config/crd/bases/admitik.freepik.com_clustermutationpolicies.yaml
@@ -41,9 +41,11 @@ spec:
             description: ClusterMutationPolicySpec defines the desired state of ClusterMutationPolicy
             properties:
               conditions:
+                description: Conditions represents a list of conditions that must
+                  be passed to meet the policy
                 items:
-                  description: ConditionT represents a canonical Kubernetes status
-                    condition for a resource
+                  description: ConditionT represents a condition that must be passed
+                    to meet the policy
                   properties:
                     engine:
                       type: string
@@ -59,18 +61,26 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               interceptedResources:
+                description: InterceptedResources represents a list of resource-groups
+                  that will be sent to the admissions server to be evaluated
                 items:
-                  description: AdmissionResourceGroupT represents a group of resources
-                    from Admission point of view
+                  description: AdmissionResourceGroupT represents a resource-group
+                    that will be sent to the admissions server to be evaluated
                   properties:
                     group:
                       type: string
                     operations:
+                      description: Conditions represents a list of conditions that
+                        must be passed to meet the policy
                       items:
                         description: OperationType specifies an operation for a request.
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     resource:
                       type: string
                     version:
@@ -82,6 +92,11 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                x-kubernetes-list-type: map
               patch:
                 properties:
                   engine:
@@ -95,14 +110,19 @@ spec:
                 - type
                 type: object
               sources:
+                description: Sources represents a list of extra resource-groups to
+                  watch and inject in templates
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -114,6 +134,13 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
             required:
             - conditions
             - interceptedResources

--- a/config/crd/bases/admitik.freepik.com_clustervalidationpolicies.yaml
+++ b/config/crd/bases/admitik.freepik.com_clustervalidationpolicies.yaml
@@ -42,9 +42,11 @@ spec:
               ClusterValidationPolicy
             properties:
               conditions:
+                description: Conditions represents a list of conditions that must
+                  be passed to meet the policy
                 items:
-                  description: ConditionT represents a canonical Kubernetes status
-                    condition for a resource
+                  description: ConditionT represents a condition that must be passed
+                    to meet the policy
                   properties:
                     engine:
                       type: string
@@ -60,20 +62,28 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               failureAction:
                 type: string
               interceptedResources:
+                description: InterceptedResources represents a list of resource-groups
+                  that will be sent to the admissions server to be evaluated
                 items:
-                  description: AdmissionResourceGroupT represents a group of resources
-                    from Admission point of view
+                  description: AdmissionResourceGroupT represents a resource-group
+                    that will be sent to the admissions server to be evaluated
                   properties:
                     group:
                       type: string
                     operations:
+                      description: Conditions represents a list of conditions that
+                        must be passed to meet the policy
                       items:
                         description: OperationType specifies an operation for a request.
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     resource:
                       type: string
                     version:
@@ -85,6 +95,11 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                x-kubernetes-list-type: map
               message:
                 properties:
                   engine:
@@ -95,14 +110,19 @@ spec:
                 - template
                 type: object
               sources:
+                description: Sources represents a list of extra resource-groups to
+                  watch and inject in templates
                 items:
-                  description: ResourceGroupT represents a group of resources
+                  description: ResourceGroupT represents a resource-group that will
+                    be watched to be evaluated
                   properties:
                     group:
                       type: string
                     name:
+                      default: ""
                       type: string
                     namespace:
+                      default: ""
                       type: string
                     resource:
                       type: string
@@ -114,6 +134,13 @@ spec:
                   - version
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - version
+                - resource
+                - name
+                - namespace
+                x-kubernetes-list-type: map
             required:
             - conditions
             - interceptedResources

--- a/docs/samples/ClusterMutationPolicy/plain_with_cel_use_strategicmerge_patch.yaml
+++ b/docs/samples/ClusterMutationPolicy/plain_with_cel_use_strategicmerge_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: admitik.freepik.com/v1alpha1
 kind: ClusterMutationPolicy
 metadata:
-  name: plain-with-cel-add-some-labels
+  name: plain-with-cel-use-strategicmerge-patch
 spec:
 
   # Resources to be intercepted before reaching the cluster
@@ -20,12 +20,11 @@ spec:
   conditions: []
 
   patch:
-    type: jsonpatch # JsonPatch | JsonMerge | StrategicMerge
+    type: strategicmerge # JsonPatch | JsonMerge | StrategicMerge
     engine: plain+cel
     template: |
-      [
-        { "op": "add", "path": "/metadata/annotations", "value": {} },
-        { "op": "add", "path": "/metadata/annotations/object-operation", "value": "{{cel: operation }}" },
-        { "op": "add", "path": "/metadata/annotations/object-kind", "value": "{{cel: object.kind }}" },
-        { "op": "add", "path": "/metadata/annotations/object-name", "value": "{{cel: object.metadata.name }}" }
-      ]
+      apiVersion: v1                                                                                                                                                                                 
+      kind: Namespace
+      metadata:
+        labels:
+          custom-label/namespace: "{{cel: object.metadata.name }}"

--- a/docs/samples/ClusterMutationPolicy/starlark_add_some_labels.yaml
+++ b/docs/samples/ClusterMutationPolicy/starlark_add_some_labels.yaml
@@ -29,7 +29,7 @@ spec:
       value: "mutate-it"
 
   patch:
-    type: jsonpatch # JsonPatch | JsonMerge
+    type: jsonpatch # JsonPatch | JsonMerge | StrategicMerge
     engine: starlark
     template: |
       def check_operation():

--- a/docs/samples/kustomization.yaml
+++ b/docs/samples/kustomization.yaml
@@ -39,6 +39,7 @@ resources:
 
 # Plain+CEL examples
 - ClusterMutationPolicy/plain_with_cel_add_some_labels.yaml
+- ClusterMutationPolicy/plain_with_cel_use_strategicmerge_patch.yaml
 
 #####################################
 ## ClusterGenerationPolicy

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	//
@@ -136,10 +137,10 @@ func CreateKubeEvent(ctx context.Context, namespace string, reporter string, obj
 		Reason:              eventReason,
 
 		Regarding: corev1.ObjectReference{
-			APIVersion: objectData["apiVersion"].(string),
-			Kind:       objectData["kind"].(string),
-			Name:       objectData["name"].(string),
-			Namespace:  objectData["namespace"].(string),
+			APIVersion: strings.Join([]string{objectData.Group, objectData.Version}, "/"),
+			Kind:       objectData.Kind,
+			Name:       objectData.Name,
+			Namespace:  objectData.Namespace,
 		},
 
 		Related: &corev1.ObjectReference{

--- a/internal/registry/sources/pool.go
+++ b/internal/registry/sources/pool.go
@@ -69,7 +69,7 @@ func (m *SourcesRegistry) RemoveResource(rt ResourceTypeName, resource *map[stri
 		}
 
 		//
-		if objectData["name"] == resourceData["name"] && objectData["namespace"] == resourceData["namespace"] {
+		if objectData.Name == resourceData.Name && objectData.Namespace == resourceData.Namespace {
 			index = itemIndex
 			break
 		}

--- a/internal/server/admission/server.go
+++ b/internal/server/admission/server.go
@@ -17,6 +17,8 @@ limitations under the License.
 package admission
 
 import (
+	"freepik.com/admitik/internal/globals"
+	"freepik.com/admitik/internal/strategicmerge"
 	"net/http"
 )
 
@@ -26,14 +28,28 @@ type HttpServer struct {
 
 	// Injected dependencies
 	dependencies *AdmissionServerDependencies
+
+	// Carried-stuff
+	strategicMergePatcher *strategicmerge.StrategicMergePatcher
 }
 
 // NewHttpServer creates a new HttpServer
-func NewHttpServer(dependencies *AdmissionServerDependencies) *HttpServer {
-	return &HttpServer{
-		&http.Server{},
-		dependencies,
+func NewHttpServer(dependencies *AdmissionServerDependencies) (*HttpServer, error) {
+
+	var err error
+	httpServer := &HttpServer{}
+	httpServer.Server = &http.Server{}
+
+	httpServer.dependencies = dependencies
+
+	httpServer.strategicMergePatcher, err = strategicmerge.NewStrategicMergePatcher(&strategicmerge.StrategicMergePatcherDependencies{
+		DiscoveryClient: globals.Application.KubeDiscoveryClient,
+	})
+	if err != nil {
+		return nil, err
 	}
+
+	return httpServer, nil
 }
 
 // setAddr sets the address for the server

--- a/internal/server/admission/server_controller.go
+++ b/internal/server/admission/server_controller.go
@@ -102,7 +102,10 @@ func (as *AdmissionServer) Start(ctx context.Context) {
 // runWebserver prepares and runs the HTTP server
 func (as *AdmissionServer) runWebserver() (err error) {
 
-	customServer := NewHttpServer(&as.dependencies)
+	customServer, err := NewHttpServer(&as.dependencies)
+	if err != nil {
+		return err
+	}
 
 	// Create the webserver to serve the requests
 	mux := http.NewServeMux()

--- a/internal/strategicmerge/errors.go
+++ b/internal/strategicmerge/errors.go
@@ -1,0 +1,25 @@
+package strategicmerge
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ExtensionGvkNotFoundInSchemaError indicates the obvious message you can read
+type ExtensionGvkNotFoundInSchemaError struct {
+	error
+}
+
+func (e *ExtensionGvkNotFoundInSchemaError) Error() string {
+	return fmt.Sprintf("extension '%v' not found in schema", extGroupVersionKind)
+}
+
+// PartialMergeError indicates that a merge operation completed,
+// but some items could not be processed due to errors.
+type PartialMergeError struct {
+	Errors []error
+}
+
+func (e *PartialMergeError) Error() string {
+	return errors.Join(e.Errors...).Error()
+}

--- a/internal/strategicmerge/strategicmerge.go
+++ b/internal/strategicmerge/strategicmerge.go
@@ -1,0 +1,617 @@
+package strategicmerge
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	//
+	"k8s.io/client-go/discovery"
+	"k8s.io/kube-openapi/pkg/util/proto"
+)
+
+const (
+	// Extension keys
+	extGroupVersionKind = "x-kubernetes-group-version-kind"
+	extMapType          = "x-kubernetes-map-type"
+	extListType         = "x-kubernetes-list-type"
+	extListMapKeys      = "x-kubernetes-list-map-keys"
+	extPatchStrategy    = "x-kubernetes-patch-strategy"
+	extPatchMergeKey    = "x-kubernetes-patch-merge-key"
+
+	// Strategy types
+	strategyMerge   = "merge"
+	strategyReplace = "replace"
+
+	// List/Map types
+	typeGranular = "granular"
+	typeAtomic   = "atomic"
+	typeMap      = "map"
+	typeSet      = "set"
+)
+
+type StrategicMergePatcherDependencies struct {
+	DiscoveryClient *discovery.DiscoveryClient
+}
+type StrategicMergePatcher struct {
+	mu sync.RWMutex
+
+	//
+	discoveryClient *discovery.DiscoveryClient
+
+	// carried stuff
+	openApiModels       *proto.Models
+	openApiSchemasByGVK map[schema.GroupVersionKind]*proto.Schema
+}
+
+func NewStrategicMergePatcher(deps *StrategicMergePatcherDependencies) (*StrategicMergePatcher, error) {
+
+	smp := &StrategicMergePatcher{
+		discoveryClient:     deps.DiscoveryClient,
+		openApiSchemasByGVK: map[schema.GroupVersionKind]*proto.Schema{},
+	}
+
+	// Initial OpenAPI models parsing
+	err := smp.updateOpenapiModels()
+	if err != nil {
+		return nil, err
+	}
+
+	// Update models periodically
+	go smp.keepUpdatedOpenapiModels()
+
+	return smp, nil
+}
+
+// updateOpenapiModels fetches the Kubernetes OpenAPI models from Kubernetes and stores them
+// in the StrategicMergePatcher as a local cache for performing queries
+func (r *StrategicMergePatcher) updateOpenapiModels() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	models, err := r.fetchOpenapiModels()
+	if err != nil {
+		return fmt.Errorf("failed getting OpenAPI models from Kubernetes: %v", err.Error())
+	}
+
+	r.openApiModels = models
+	r.openApiSchemasByGVK, err = r.getMappedSchemasByGVK(models)
+	if err != nil {
+		return fmt.Errorf("failed getting schemas from OpenAPI models: %v", err.Error())
+	}
+
+	return nil
+}
+
+// keepUpdatedOpenapiModels updates local cache of Kubernetes OpenAPI models periodically
+// This function intended to be executed as a goroutine
+func (r *StrategicMergePatcher) keepUpdatedOpenapiModels() {
+	for {
+		err := r.updateOpenapiModels()
+		if err != nil {
+			log.Printf("%v", err.Error())
+			goto takeANap
+		}
+
+	takeANap:
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// fetchOpenapiModels returns Kubernetes OpenAPI models
+func (r *StrategicMergePatcher) fetchOpenapiModels() (*proto.Models, error) {
+	openapiSchema, err := r.discoveryClient.OpenAPISchema()
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := proto.NewOpenAPIData(openapiSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models, nil
+}
+
+// getMappedSchemasByGVK receives the OpenAPI models and returns a map of Schemas with GVKs as indexes
+func (r *StrategicMergePatcher) getMappedSchemasByGVK(models *proto.Models) (result map[schema.GroupVersionKind]*proto.Schema, err error) {
+
+	result = map[schema.GroupVersionKind]*proto.Schema{}
+
+	errorList := []error{}
+
+	for _, modelName := range (*models).ListModels() {
+		modelSchema := (*r.openApiModels).LookupModel(modelName)
+		if modelSchema == nil {
+			continue
+		}
+
+		// Extract as much GVKs as model has
+		var gvkList []schema.GroupVersionKind
+		gvkList, err = r.GetSchemaGVK(modelSchema)
+		if err != nil {
+			// Ignore 'GVK not found' errors as child schemas have NOT a GVK
+			gvkNotFoundErr := &ExtensionGvkNotFoundInSchemaError{}
+			if errors.As(err, &gvkNotFoundErr) {
+				continue
+			}
+
+			//
+			errorList = append(errorList, err)
+			continue
+		}
+
+		for _, gvk := range gvkList {
+			result[gvk] = &modelSchema
+		}
+	}
+
+	return result, errors.Join(errorList...)
+}
+
+// GetModelSchema returns a Schema for the given model name
+// Example: 'io.k8s.api.core.v1.Volume' -> proto.Schema
+func (r *StrategicMergePatcher) GetModelSchema(modelName string) proto.Schema {
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return (*r.openApiModels).LookupModel(modelName)
+}
+
+// resolveSchemaReference receives a Schema and returns it back.
+// When the Schema is a reference under the hood, it returns the dereferenced Schema instead
+// This function only resolves one level of reference
+func (r *StrategicMergePatcher) resolveSchemaReference(schema proto.Schema) (proto.Schema, error) {
+
+	if schema == nil {
+		return schema, fmt.Errorf("nil schema provided")
+	}
+
+	ref, schemaIsAReference := schema.(*proto.Ref)
+	if !schemaIsAReference {
+		return schema, nil
+	}
+
+	modelName := filepath.Base(ref.Reference())
+	resolvedSchema := r.GetModelSchema(modelName)
+
+	if resolvedSchema != nil {
+		return resolvedSchema, nil
+	}
+
+	return nil, fmt.Errorf("schema not found for model '%v'", modelName)
+}
+
+// GetSchemaGVK returns the list of GVKs for the given Schema
+func (r *StrategicMergePatcher) GetSchemaGVK(modelSchema proto.Schema) (result []schema.GroupVersionKind, err error) {
+
+	var errorList []error
+
+	// Extract as much GVKs as model has
+	modelSchemaGVK, modelSchemaHasGvk := modelSchema.GetExtensions()[extGroupVersionKind]
+	if !modelSchemaHasGvk {
+		return nil, &ExtensionGvkNotFoundInSchemaError{}
+	}
+
+	rawGVKListConverted, rawGVKListConversionOk := modelSchemaGVK.([]interface{})
+	if !rawGVKListConversionOk {
+		return nil, fmt.Errorf("impossible to assert GVK list for schema")
+	}
+
+	for _, rawGVKItem := range rawGVKListConverted {
+
+		gvkMap, ok := rawGVKItem.(map[interface{}]interface{})
+		if !ok {
+			errorList = append(errorList, fmt.Errorf("failed asserting GVK item for schema"))
+			continue
+		}
+
+		//
+		groupRaw, groupOk := gvkMap["group"]
+		versionRaw, versionOk := gvkMap["version"]
+		kindRaw, kindOk := gvkMap["kind"]
+
+		if !groupOk || !versionOk || !kindOk {
+			errorList = append(errorList, fmt.Errorf("incomplete GVK in schema"))
+			continue
+		}
+
+		//
+		group, groupStringOk := groupRaw.(string)
+		version, versionStringOk := versionRaw.(string)
+		kind, kindStringOk := kindRaw.(string)
+
+		if !groupStringOk || !versionStringOk || !kindStringOk {
+			errorList = append(errorList, fmt.Errorf("GVK fields are not strings in schema"))
+			continue
+		}
+
+		//
+		gvk := schema.GroupVersionKind{
+			Group:   group,
+			Version: version,
+			Kind:    kind,
+		}
+
+		result = append(result, gvk)
+	}
+
+	return result, errors.Join(errorList...)
+}
+
+// GetSchemaByGVK returns the Schema for the given GVK
+func (r *StrategicMergePatcher) GetSchemaByGVK(gvk schema.GroupVersionKind) proto.Schema {
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tmpSchema, tmpSchemaFound := r.openApiSchemasByGVK[gvk]
+	if !tmpSchemaFound {
+		return nil
+	}
+
+	return *tmpSchema
+}
+
+// schemaPatchStrategyInfo represents the strategy used to merge maps or lists
+// and the relevant keys used during the process.
+type schemaPatchStrategyInfo struct {
+	Strategy  string
+	MergeKeys []string
+}
+
+// getPatchStrategyFromSchema inspects a field's Schema and determines its patching strategy.
+// It prioritizes 'x-kubernetes-map-type' and 'x-kubernetes-list-type' definitions (common in CRDs for map and list topology)
+// over 'x-kubernetes-patch-strategy' (for traditional Strategic Merge Patch).
+// Ref: https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apis/apiextensions/types_jsonschema.go#L110-L152
+// Ref: https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy
+func getPatchStrategyFromSchema(schema proto.Schema) schemaPatchStrategyInfo {
+	// If no schema is provided, the default behavior for a field is "replace".
+	if schema == nil {
+		return schemaPatchStrategyInfo{Strategy: strategyReplace}
+	}
+
+	extensions := schema.GetExtensions()
+
+	// Priority 1: Check for x-kubernetes-map-type, which describes the map's topology.
+	if mapType, ok := extensions[extMapType].(string); ok {
+		switch mapType {
+		case typeGranular:
+			// For "granular" maps, they can be merged as usual
+			return schemaPatchStrategyInfo{Strategy: strategyMerge, MergeKeys: []string{}}
+
+		case typeAtomic:
+			// For "atomic" maps, the entire map is always replaced.
+			return schemaPatchStrategyInfo{Strategy: strategyReplace}
+		}
+	}
+
+	// Priority 2: Check for x-kubernetes-list-type, which describes the list's topology.
+	if listType, ok := extensions[extListType].(string); ok {
+		switch listType {
+
+		case typeMap:
+
+			// For "map" lists, look for x-kubernetes-list-map-keys to identify merge keys.
+			if mapKeysRaw, ok := extensions[extListMapKeys].([]interface{}); ok {
+				mergeKeys := make([]string, 0, len(mapKeysRaw))
+				for _, key := range mapKeysRaw {
+					if s, isString := key.(string); isString {
+						mergeKeys = append(mergeKeys, s)
+					}
+				}
+
+				if len(mergeKeys) > 0 {
+					return schemaPatchStrategyInfo{Strategy: strategyMerge, MergeKeys: mergeKeys}
+				}
+			}
+
+			// For map-keys being absent or invalid, the merge behavior is undefined.
+			// Default to "replace" for safety.
+			return schemaPatchStrategyInfo{Strategy: strategyReplace}
+
+		case typeSet:
+			// For "set" lists, elements are unique by value. The strategy is "merge",
+			// but no explicit merge keys are used (the entire item value acts as its key).
+			return schemaPatchStrategyInfo{Strategy: strategyMerge, MergeKeys: []string{}}
+
+		case typeAtomic:
+			// For "atomic" lists, the entire list is always replaced.
+			return schemaPatchStrategyInfo{Strategy: strategyReplace}
+		}
+	}
+
+	// Priority 3: If no specific x-kubernetes-list-type was defined or relevant,
+	// check for x-kubernetes-patch-strategy for traditional Strategic Merge Patch behavior.
+	if strategy, ok := extensions[extPatchStrategy].(string); ok && strings.Contains(strategy, strategyMerge) {
+
+		// If the strategy is "merge", look for x-kubernetes-patch-merge-key.
+		if mergeKey, ok := extensions[extPatchMergeKey].(string); ok {
+			return schemaPatchStrategyInfo{Strategy: strategyMerge, MergeKeys: []string{mergeKey}}
+		}
+
+		// If it's "merge" but there's no patch-merge-key (e.g., for scalar lists that merge by appending unique items).
+		return schemaPatchStrategyInfo{Strategy: strategyMerge, MergeKeys: []string{}}
+	}
+
+	// Default behavior for map-like objects (structs) is "merge".
+	if _, ok := schema.(*proto.Kind); ok {
+		return schemaPatchStrategyInfo{Strategy: strategyMerge, MergeKeys: []string{}}
+	}
+
+	// Default behavior: If no explicit merge strategy or list type is found,
+	// the field is entirely replaced.
+	return schemaPatchStrategyInfo{Strategy: strategyReplace}
+}
+
+// generateCompositeKey creates a stable, unique string key from an item's specified merge fields.
+func generateCompositeKey(item map[string]interface{}, mergeKeys []string) (string, error) {
+	var parts []string
+	for _, key := range mergeKeys {
+
+		value, exists := item[key]
+		if !exists {
+			return "", fmt.Errorf("merge key field '%s' is missing in item: %v", key, item)
+		}
+
+		valString := fmt.Sprintf("%v", value)
+
+		parts = append(parts, valString)
+	}
+
+	// Use a separator unlikely to appear in actual field values.
+	return strings.Join(parts, "::"), nil
+}
+
+// mergeScalarList handles merging of lists without explicit merge keys (e.g., lists of strings/ints, or "set" lists).
+// It adds unique elements from the patch to the original.
+func mergeScalarList(original, patch []interface{}) []interface{} {
+	seen := make(map[interface{}]struct{})
+	result := make([]interface{}, 0, len(original)+len(patch))
+
+	// Add all original unique items
+	for _, item := range original {
+		if _, exists := seen[item]; !exists {
+			result = append(result, item)
+			seen[item] = struct{}{}
+		}
+	}
+
+	// Add unique items from patch that are not already in original
+	for _, item := range patch {
+		if _, exists := seen[item]; !exists {
+			result = append(result, item)
+			seen[item] = struct{}{}
+		}
+	}
+	return result
+}
+
+// mergeLists merges two lists based on the provided patch strategy information.
+func (r *StrategicMergePatcher) mergeLists(original, patch []interface{}, patchInfo schemaPatchStrategyInfo, listSchema proto.Schema) ([]interface{}, error) {
+	// Strategy is not "merge": replace the original list with the patch list.
+	if patchInfo.Strategy != strategyMerge {
+		return patch, nil
+	}
+
+	// Strategy is "merge" but no merge keys are provided (e.g., for "set" lists or scalar lists),
+	// we perform a simple append of unique elements.
+	if len(patchInfo.MergeKeys) == 0 {
+		return mergeScalarList(original, patch), nil
+	}
+
+	// Get item schema for recursive merging of list elements.
+	var itemSchema proto.Schema
+	if arraySchema, ok := listSchema.(*proto.Array); ok {
+		// itemSchema can be a reference. We don't need to resolve it as this function will call
+		// StrategicMerge() for merging maps, which is always resolving them in the beginning
+		itemSchema = arraySchema.SubType
+	}
+
+	// Create an index of patch items by their composite key for efficient lookup.
+	patchIndex := make(map[string]map[string]interface{})
+	for _, item := range patch {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			// Skip non-map items in a merge-keyed list
+			continue
+		}
+
+		compositeKey, err := generateCompositeKey(itemMap, patchInfo.MergeKeys)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate composite key for patch item: %v (error: %v)", item, err)
+		}
+
+		// Key generation failed (e.g., missing required key fields)
+		if compositeKey == "" {
+			return nil, fmt.Errorf("missing required key fields")
+		}
+		patchIndex[compositeKey] = itemMap
+	}
+
+	var resultList []interface{}
+	var partialProcessingErrors []error
+
+	// Iterate through the original list to merge or keep items.
+	for originalItemIndex, originalItem := range original {
+		originalItemMap, ok := originalItem.(map[string]interface{})
+		if !ok {
+			partialProcessingErrors = append(partialProcessingErrors, fmt.Errorf("original list item at index %d is not an object; cannot merge by key. Item: %v", originalItemIndex, originalItem))
+
+			// If original item is not a map, it cannot be merged by key; append it as is.
+			resultList = append(resultList, originalItem)
+			continue
+		}
+
+		compositeKey, err := generateCompositeKey(originalItemMap, patchInfo.MergeKeys)
+		if err != nil {
+			partialProcessingErrors = append(partialProcessingErrors, fmt.Errorf("failed to generate composite key for original list item at index %d: %w. Item will be appended without merge attempt", originalItemIndex, err))
+
+			// If original item's key cannot be generated, append it as is.
+			resultList = append(resultList, originalItem)
+			continue
+		}
+
+		if compositeKey == "" {
+			partialProcessingErrors = append(partialProcessingErrors, fmt.Errorf("empty composite key generated for original list item at index %d, indicating missing required fields. Item will be appended without merge attempt", originalItemIndex))
+			resultList = append(resultList, originalItem)
+			continue
+		}
+
+		// If a matching item exists in the patch, merge it.
+		if patchItemMap, inPatch := patchIndex[compositeKey]; inPatch {
+			mergedItem, mergeErr := r.StrategicMerge(originalItemMap, patchItemMap, itemSchema)
+			if mergeErr != nil {
+				partialErr := &PartialMergeError{}
+				if errors.As(mergeErr, &partialErr) {
+					partialProcessingErrors = append(partialProcessingErrors, partialErr.Errors...)
+				} else {
+					return nil, mergeErr
+				}
+			}
+
+			resultList = append(resultList, mergedItem)
+
+			// Remove from index as it's been processed
+			delete(patchIndex, compositeKey)
+		} else {
+			// If no matching item in patch, keep the original.
+			resultList = append(resultList, originalItem)
+		}
+	}
+
+	// Add any remaining items from the patch (new items).
+	newKeys := make([]string, 0, len(patchIndex))
+	for k := range patchIndex {
+		newKeys = append(newKeys, k)
+	}
+
+	// Ensure deterministic order for new items
+	sort.Strings(newKeys)
+
+	for _, k := range newKeys {
+		resultList = append(resultList, patchIndex[k])
+	}
+
+	if len(partialProcessingErrors) > 0 {
+		return resultList, &PartialMergeError{Errors: partialProcessingErrors}
+	}
+
+	return resultList, nil
+}
+
+// StrategicMerge performs a strategic merge on two map[string]interface{} objects.
+func (r *StrategicMergePatcher) StrategicMerge(original, patch map[string]interface{}, schema proto.Schema) (map[string]interface{}, error) {
+	var err error
+
+	// 1. Resolve Schema references if applicable.
+	// This ensures we always work with a concrete schema for field lookups.
+	schema, err = r.resolveSchemaReference(schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed resolving schema reference: %v", err.Error())
+	}
+
+	result, err := DeepCopyMap(original)
+	if err != nil {
+		return nil, fmt.Errorf("failed deep-copying original object: %w", err)
+	}
+
+	result = SanitizeNils(result)
+
+	// 2. Iterate over fields in 'patch' looking for them in the 'original' object.
+	// Depending on the type of field (map, list or primitive), perform the most suitable type of merge,
+	// then overwrite the entire field in the original object
+	var mergeErrors []error // Collect errors during the merge operation
+
+	for patchKey, patchValue := range patch {
+
+		originalValue, originalExists := result[patchKey]
+
+		// Get schema for the current field being processed.
+		// TODO: Can we resolve here and avoid the first transformation? lets see in later iterations
+		var fieldSchema proto.Schema
+		if kindSchema, ok := schema.(*proto.Kind); ok {
+			fieldSchema = kindSchema.Fields[patchKey]
+
+			// Fail when 'patch' have unknown fields. Patch must make sense like perfection of a smooth ice-cream
+			if fieldSchema == nil {
+				return nil, fmt.Errorf("patch is malformed. Invalid field '%v' in '%v'", patchKey, kindSchema.BaseSchema.Path.String())
+
+				// TODO: Ignore fields instead?
+				//continue
+			}
+
+			fieldSchema, err = r.resolveSchemaReference(fieldSchema)
+			if err != nil {
+				return nil, fmt.Errorf("failed resolving child schema reference for patch key '%v': %v", patchKey, err.Error())
+			}
+		}
+
+		switch {
+		case isMap(patchValue) && isMap(originalValue):
+			patchInfo := getPatchStrategyFromSchema(fieldSchema)
+			if patchInfo.Strategy == strategyReplace {
+				// The map is "atomic", so we replace it entirely.
+				result[patchKey] = patchValue
+			} else {
+
+				// The map is "granular" (or no strategy specified), perform a recursive strategic merge.
+				merged, mergeErr := r.StrategicMerge(originalValue.(map[string]interface{}), patchValue.(map[string]interface{}), fieldSchema)
+				if mergeErr != nil {
+					partialErr := &PartialMergeError{}
+					if errors.As(mergeErr, &partialErr) {
+						// Accumulate partial errors
+						mergeErrors = append(mergeErrors, partialErr.Errors...)
+					} else {
+						return nil, mergeErr
+					}
+				}
+				result[patchKey] = merged
+			}
+
+		case isList(patchValue):
+
+			// Patch value is a list, apply list merging strategy.
+			patchInfo := getPatchStrategyFromSchema(fieldSchema)
+
+			originalList := []interface{}{} // Initialize empty list if original doesn't exist or isn't a list
+			if originalExists {
+				if ol, ok := originalValue.([]interface{}); ok {
+					originalList = ol
+				}
+			}
+
+			mergedList, mergeErr := r.mergeLists(originalList, patchValue.([]interface{}), patchInfo, fieldSchema)
+			if mergeErr != nil {
+				partialErr := &PartialMergeError{}
+				if errors.As(mergeErr, &partialErr) {
+					// Accumulate partial errors
+					mergeErrors = append(mergeErrors, partialErr.Errors...)
+				} else {
+					return nil, mergeErr
+				}
+			}
+			result[patchKey] = mergedList
+
+		default:
+			// For primitive types or type mismatches, replace if different or new.
+			if !originalExists || !reflect.DeepEqual(originalValue, patchValue) {
+				result[patchKey] = patchValue
+			}
+		}
+	}
+
+	if len(mergeErrors) > 0 {
+		return result, &PartialMergeError{Errors: mergeErrors}
+	}
+
+	return result, nil
+}

--- a/internal/strategicmerge/utils.go
+++ b/internal/strategicmerge/utils.go
@@ -1,0 +1,85 @@
+package strategicmerge
+
+import (
+	"bytes"
+	"encoding/gob"
+	"reflect"
+)
+
+func init() {
+	gob.Register(map[string]interface{}{})
+	gob.Register([]interface{}{})
+}
+
+// DeepCopyMap performs a deep copy of the given map m.
+func DeepCopyMap(m map[string]interface{}) (map[string]interface{}, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	dec := gob.NewDecoder(&buf)
+	err := enc.Encode(m)
+	if err != nil {
+		return nil, err
+	}
+
+	var tmpCopy map[string]interface{}
+	err = dec.Decode(&tmpCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpCopy, nil
+}
+
+// isMap return whether an interface is a map under the hood
+func isMap(val interface{}) bool {
+	_, ok := val.(map[string]interface{})
+	return ok
+}
+
+// isList return whether an interface is a list under the hood
+func isList(val interface{}) bool {
+	_, ok := val.([]interface{})
+	return ok
+}
+
+// SanitizeNils recursively traverses a map and replaces both nil slices and nil maps
+// with their empty, non-nil equivalents ({} and []).
+// This is useful for preparing data structures for JSON serialization where 'null' is undesirable for empty collections.
+func SanitizeNils(m map[string]interface{}) map[string]interface{} {
+	for k, v := range m {
+		// If the value is a raw nil interface{}, we cannot know its original intended type
+		// (map or slice). We leave it as is, and it will serialize to 'null'. This is an
+		// edge case and typically doesn't happen with well-formed JSON/YAML input.
+		if v == nil {
+			continue
+		}
+
+		// Use reflect to inspect the underlying type of the interface{}
+		t := reflect.TypeOf(v)
+		val := reflect.ValueOf(v)
+
+		switch t.Kind() {
+		case reflect.Map:
+			if val.IsNil() {
+				m[k] = make(map[string]interface{})
+			} else {
+				m[k] = SanitizeNils(v.(map[string]interface{}))
+			}
+
+		case reflect.Slice:
+			if val.IsNil() {
+				m[k] = []interface{}{}
+			} else {
+				// If not nil, iterate over its elements to find nested maps
+				// that might also need sanitization.
+				subList := v.([]interface{})
+				for i, item := range subList {
+					if itemMap, ok := item.(map[string]interface{}); ok {
+						subList[i] = SanitizeNils(itemMap)
+					}
+				}
+			}
+		}
+	}
+	return m
+}


### PR DESCRIPTION
**Description:**
- **Refactor some helper functions to make them more re-usable and robust**
- **Add StrategicMerge patcher package**: 
  - This package is published with important methods exported to allow other projects use the package as a library (there is not another easy-to-use package for this stuff nowhere 🤯 )
  - Support `x-kubernetes-patch-*`, `x-kubernetes-list-*` and `x-kubernetes-map-*` extensions, so it can patch CRDs that are properly defined too
- **Add StrategicMerge capabilities to ClusterMutationPolicy resources**
- **Add some examples in `docs/samples` directory**

**Notes:**
This fixes #21 